### PR TITLE
Fix compiler warnings of unused parameter

### DIFF
--- a/src/Weekly.cpp
+++ b/src/Weekly.cpp
@@ -92,7 +92,7 @@ DateTime Weekly::previous(const DateTime & dt) const {
 	return thePrev;
 
 }
-DateTime Weekly::applyTo(const DateTime & dt, Direction dir) const {
+DateTime Weekly::applyTo(const DateTime & dt, Direction /*dir*/) const {
 	Chronos::TimeElements els(dt.asElements());
 
 	/*

--- a/src/Yearly.cpp
+++ b/src/Yearly.cpp
@@ -66,7 +66,7 @@ DateTime Yearly::previous(const DateTime& dt) const {
 	return thePrev;
 }
 
-DateTime Yearly::applyTo(const DateTime& dt, Direction dir) const {
+DateTime Yearly::applyTo(const DateTime& dt, Direction /*dir*/) const {
 	Chronos::TimeElements els(dt.asElements());
 
 	els.Month = month;


### PR DESCRIPTION
Compiling with warnings enabled currently gives the following warnings for this library:

.../libraries/Chronos/src/Yearly.cpp:69:56: warning: unused parameter 'dir' [-Wunused-parameter]
 DateTime Yearly::applyTo(const DateTime& dt, Direction dir) const {
                                                        ^
.../libraries/Chronos/src/Weekly.cpp:95:57: warning: unused parameter 'dir' [-Wunused-parameter]
 DateTime Weekly::applyTo(const DateTime & dt, Direction dir) const {
                                                         ^